### PR TITLE
Find The Original Array of Prefix Xor

### DIFF
--- a/Add Code Here/C++/leetcode/2433. Find The Original Array of Prefix Xor.cpp
+++ b/Add Code Here/C++/leetcode/2433. Find The Original Array of Prefix Xor.cpp
@@ -1,0 +1,21 @@
+// Problem Link : https://leetcode.com/problems/find-the-original-array-of-prefix-xor/
+
+// Vector : Vectors are the same as dynamic arrays with the ability to resize itself automatically when an element is inserted or deleted, with their storage being handled automatically by the container. Vector elements are placed in contiguous storage so that they can be accessed and traversed using iterators
+class Solution
+{
+public:
+    vector<int> findArray(vector<int> &pref)
+    {
+        vector<int> result;
+        // Remember the property : if a ^ b = c then b ^ c = a and a ^ c = b
+        for (int i = 0; i < pref.size(); i++)
+        {
+            if (i == 0)
+                result.push_back(pref[i]);
+            else
+                // Xor of previous value with the current value
+                result.push_back(pref[i - 1] ^ pref[i]);
+        }
+        return result;
+    }
+};


### PR DESCRIPTION
LeetCode
Problem Link : Problem Link : https://leetcode.com/problems/find-the-original-array-of-prefix-xor/
Difficulty : Medium

Description : You are given an integer array pref of size n. Find and return the array arr of size n that satisfies:
pref[i] = arr[0] ^ arr[1] ^ ... ^ arr[i].
Note that ^ denotes the bitwise-xor operation.
It can be proven that the answer is unique.

Solution : Explained the code , line by line.
@ossamamehmood , please review this.
Thank You.